### PR TITLE
Fix labels

### DIFF
--- a/Trainer.py
+++ b/Trainer.py
@@ -42,7 +42,7 @@ class LightningModel(pl.LightningModule):
 
         train_data = pd.read_csv(os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_train.csv"))
         train_dataset = DADataset(tokenizer=self.tokenizer, data=train_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'])
-        self.classes = train_dataset.__label_dict
+        self.classes = train_dataset.label_dict
 
     def forward(self, batch):
         logits  = self.model(batch)
@@ -54,7 +54,7 @@ class LightningModel(pl.LightningModule):
     def train_dataloader(self):
         # train_data = load_dataset("csv", data_files=os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_train.csv"))
         train_data = pd.read_csv(os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_train.csv"))
-        train_dataset = DADataset(tokenizer=self.tokenizer, data=train_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'], classes=self.classes)
+        train_dataset = DADataset(tokenizer=self.tokenizer, data=train_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'], label_dict=self.classes)
         train_loader = DataLoader(dataset=train_dataset, batch_size=self.config['batch_size'], shuffle=False, num_workers=self.config['num_workers'])
         return train_loader
     
@@ -72,7 +72,7 @@ class LightningModel(pl.LightningModule):
     def val_dataloader(self):
         #valid_data = load_dataset("csv", data_files=os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_valid.csv"))
         valid_data = pd.read_csv(os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_valid.csv")) # valid has ~40k samples this is valid is same as test to run it quickely, test has ~16k samples
-        valid_dataset = DADataset(tokenizer=self.tokenizer, data=valid_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'], classes=self.classes)
+        valid_dataset = DADataset(tokenizer=self.tokenizer, data=valid_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'], label_dict=self.classes)
         valid_loader = DataLoader(dataset=valid_dataset, batch_size=self.config['batch_size'], shuffle=False, num_workers=self.config['num_workers'])
         return valid_loader
     
@@ -98,7 +98,7 @@ class LightningModel(pl.LightningModule):
     def test_dataloader(self):
         #test_data = load_dataset("csv", data_files=os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_test.csv"))
         test_data = pd.read_csv(os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_test.csv"))
-        test_dataset = DADataset(tokenizer=self.tokenizer, data=test_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'], classes=self.classes)
+        test_dataset = DADataset(tokenizer=self.tokenizer, data=test_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'], label_dict=self.classes)
         test_loader = DataLoader(dataset=test_dataset, batch_size=self.config['batch_size'], shuffle=False, num_workers=self.config['num_workers'])
         return test_loader
     

--- a/Trainer.py
+++ b/Trainer.py
@@ -39,7 +39,11 @@ class LightningModel(pl.LightningModule):
             device=self.config['device']
         )
         self.tokenizer = AutoTokenizer.from_pretrained(config['model_name'])
-        
+
+        train_data = pd.read_csv(os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_train.csv"))
+        train_dataset = DADataset(tokenizer=self.tokenizer, data=train_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'])
+        self.classes = train_dataset.__label_dict
+
     def forward(self, batch):
         logits  = self.model(batch)
         return logits
@@ -50,7 +54,7 @@ class LightningModel(pl.LightningModule):
     def train_dataloader(self):
         # train_data = load_dataset("csv", data_files=os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_train.csv"))
         train_data = pd.read_csv(os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_train.csv"))
-        train_dataset = DADataset(tokenizer=self.tokenizer, data=train_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'])
+        train_dataset = DADataset(tokenizer=self.tokenizer, data=train_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'], classes=self.classes)
         train_loader = DataLoader(dataset=train_dataset, batch_size=self.config['batch_size'], shuffle=False, num_workers=self.config['num_workers'])
         return train_loader
     
@@ -68,7 +72,7 @@ class LightningModel(pl.LightningModule):
     def val_dataloader(self):
         #valid_data = load_dataset("csv", data_files=os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_valid.csv"))
         valid_data = pd.read_csv(os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_valid.csv")) # valid has ~40k samples this is valid is same as test to run it quickely, test has ~16k samples
-        valid_dataset = DADataset(tokenizer=self.tokenizer, data=valid_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'])
+        valid_dataset = DADataset(tokenizer=self.tokenizer, data=valid_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'], classes=self.classes)
         valid_loader = DataLoader(dataset=valid_dataset, batch_size=self.config['batch_size'], shuffle=False, num_workers=self.config['num_workers'])
         return valid_loader
     
@@ -94,7 +98,7 @@ class LightningModel(pl.LightningModule):
     def test_dataloader(self):
         #test_data = load_dataset("csv", data_files=os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_test.csv"))
         test_data = pd.read_csv(os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_test.csv"))
-        test_dataset = DADataset(tokenizer=self.tokenizer, data=test_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'])
+        test_dataset = DADataset(tokenizer=self.tokenizer, data=test_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'], classes=self.classes)
         test_loader = DataLoader(dataset=test_dataset, batch_size=self.config['batch_size'], shuffle=False, num_workers=self.config['num_workers'])
         return test_loader
     

--- a/Trainer.py
+++ b/Trainer.py
@@ -42,7 +42,7 @@ class LightningModel(pl.LightningModule):
 
         train_data = pd.read_csv(os.path.join(self.config['data_dir'], self.config['dataset'], self.config['dataset']+"_train.csv"))
         train_dataset = DADataset(tokenizer=self.tokenizer, data=train_data, max_len=self.config['max_len'], text_field=self.config['text_field'], label_field=self.config['label_field'])
-        self.classes = train_dataset.label_dict
+        self.classes = train_dataset.label_dict()
 
     def forward(self, batch):
         logits  = self.model(batch)

--- a/dataset/dataset.py
+++ b/dataset/dataset.py
@@ -5,20 +5,23 @@ class DADataset(Dataset):
     
     __label_dict = dict()
     
-    def __init__(self, tokenizer, data, text_field = "clean_text", label_field="act_label_1", max_len=512):
+    def __init__(self, tokenizer, data, text_field = "clean_text", label_field="act_label_1", max_len=512, label_dict=None):
         
         self.text = list(data[text_field]) #data['train'][text_field]
         self.acts = list(data[label_field]) #['train'][label_field]
         self.tokenizer = tokenizer
         self.max_len = max_len
         
+
+        if label_dict is None:
+            # build/update the label dictionary
+            classes = sorted(set(self.acts))
         
-        # build/update the label dictionary 
-        classes = sorted(set(self.acts))
-        
-        for cls in classes:
-            if cls not in DADataset.__label_dict.keys():
-                DADataset.__label_dict[cls]=len(DADataset.__label_dict.keys())
+            for cls in classes:
+                if cls not in DADataset.__label_dict.keys():
+                    DADataset.__label_dict[cls]=len(DADataset.__label_dict.keys())
+        else:
+            DADataset.__label_dict = label_dict
     
     def __len__(self):
         return len(self.text)


### PR DESCRIPTION
Temporary fix for issue https://github.com/macabdul9/CASA-Dialogue-Act-Classifier/issues/10

It's not very elegant, but it fixes the problem that different data splits use different dictionaries when they don't all contain the same labels